### PR TITLE
Fix: functions with a `.` which are already qualified, like `utils::as.roman(123)`

### DIFF
--- a/R/add_double_colons.R
+++ b/R/add_double_colons.R
@@ -71,7 +71,7 @@ add_double_colons <- function(code = NULL,
 
   # Regular expression to extract function calls
   backticks_fns <- "`[^`]+`(?= *[(])"
-  syntactic_fns <- "(?<=[^a-zA-Z_]|^)[a-zA-Z._]+(?= *[(])"
+  syntactic_fns <- "(?<=[^a-zA-Z._]|^)[a-zA-Z._]+(?= *[(])"
   exclude_dcs   <- "(?<!::)"
   funs_regex    <- sprintf("%s(%s|%s)", exclude_dcs, backticks_fns, syntactic_fns)
 

--- a/tests/testthat/test-add_double_colons.R
+++ b/tests/testthat/test-add_double_colons.R
@@ -20,9 +20,19 @@ test_that("add_double_colons works", {
     "dplyr::tibble(x = 1); anotherPkg::some_fun()"
   )
 
+  expect_equal(
+    add_double_colons("utils::as.roman(12)", "utils"),
+    "utils::as.roman(12)"
+  )
+
   expect_warning(
     add_double_colons("tibble(x = 1); some_fun()", "dplyr"),
     "Couldn't find packages exporting 1 function\\(s\\): `some_fun\\(\\)`"
   )
-
+  
+  expect_warning(
+    add_double_colons("tibble(x = 1); some_fun()", "dplyr"),
+    "Couldn't find packages exporting 1 function\\(s\\): `some_fun\\(\\)`"
+  )
+  
 })


### PR DESCRIPTION
Fixes #10